### PR TITLE
Убрал войска РФ с территории ЛДНР

### DIFF
--- a/history/units/RUS_2022.txt
+++ b/history/units/RUS_2022.txt
@@ -4140,7 +4140,7 @@ units = {
 
 	division = {
 		name = "281-yy otdel'nyy otryad spetsial'nogo naznacheniya 24-ya otdel'naya Brandenburgskaya brigada spetsial'nogo naznacheniya"
-		location = 18729
+		location = 15909
 		division_template = "Pechotniy batalion" #изменить на ССО
 		start_experience_factor = 0.3
 		start_equipment_factor = 0.01
@@ -4163,7 +4163,7 @@ units = {
 
 	division = {
 		name = "3-y tankovyy batal'on 68-oy gvardeyskiy tankovyy Zhitomirsko-Berlinskiy polk"
-		location = 16125
+		location = 16085
 		division_template = "Batalion T72" 
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
@@ -4171,7 +4171,7 @@ units = {
 
 	division = {
 		name = "1-y artileriyskiy batal'on 68-oy gvardeyskiy tankovyy Zhitomirsko-Berlinskiy polk"
-		location = 16125
+		location = 16085
 		division_template = "Artileriysky batalion" 
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
@@ -4179,7 +4179,7 @@ units = {
 
 	division = {
 		name = "3-y tankovyy batal'on 163-y gvardeyskiy tankovyy Nezhinskiy polk"
-		location = 5407
+		location = 1393
 		division_template = "Batalion T72" 
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
@@ -4187,7 +4187,7 @@ units = {
 
 	division = {
 		name = "1-y artileriyskiy batal'on 163-y gvardeyskiy tankovyy Nezhinskiy polk"
-		location = 5407
+		location = 1393
 		division_template = "Artileriysky batalion" 
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
@@ -4195,7 +4195,7 @@ units = {
 
 	division = {
 		name = "1-y tankovyy batal'on 102-oy motostrelkovyy Slonimsko-Pomeranskiy polk"
-		location = 15082
+		location = 8283
 		division_template = "Batalion T72" 
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
@@ -4203,7 +4203,7 @@ units = {
 
 	division = {
 		name = "1-y artileriyskiy batal'on 102-oy motostrelkovyy Slonimsko-Pomeranskiy polk"
-		location = 15082
+		location = 8283
 		division_template = "Artileriysky batalion" 
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
@@ -4211,7 +4211,7 @@ units = {
 
 	division = {
 		name = "1-y tankovyy batal'on 103-y motostrelkovyy polk"
-		location = 1492
+		location = 10964
 		division_template = "Batalion T72" 
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
@@ -4219,7 +4219,7 @@ units = {
 
 	division = {
 		name = "1-y artileriyskiy batal'on 103-y motostrelkovyy polk"
-		location = 1492
+		location = 10964
 		division_template = "Artileriysky batalion" 
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
@@ -4227,7 +4227,7 @@ units = {
 
 	division = {
 		name = "2-y artileriyskiy batal'on 205-y otdel'naya motostrelkovaya brigada"
-		location = 1492
+		location = 10964
 		division_template = "Artileriysky batalion" 
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
@@ -4235,21 +4235,21 @@ units = {
 
 	division = {
 		name = "1-yy motostrelkovyy batal'on 7-oy otdel'nyy gvardeyskiy motostrelkovyy polk"
-		location = 15830
+		location = 16021
 		division_template = "Motostrelkoviy batalion"
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
 	}
 	division = {
 		name = "2-yy motostrelkovyy batal'on 7-oy otdel'nyy gvardeyskiy motostrelkovyy polk"
-		location = 15830
+		location = 16021
 		division_template = "Motostrelkoviy batalion"
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
 	}
 	division = {
 		name = "3-yy motostrelkovyy batal'on 7-oy otdel'nyy gvardeyskiy motostrelkovyy polk"
-		location = 15830
+		location = 16021
 		division_template = "Motostrelkoviy batalion"
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
@@ -4257,7 +4257,7 @@ units = {
 
 	division = {
 		name = "1-yy artileriyskiy batal'on 7-oy otdel'nyy gvardeyskiy motostrelkovyy polk"
-		location = 5074
+		location = 18863
 		division_template = "Artileriysky batalion"
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
@@ -4265,7 +4265,7 @@ units = {
 
 	division = {
 		name = "1-yy artileriyskiy batal'on 80-oy otdel'nyy motostrelkovyy brigady"
-		location = 5074
+		location = 18863
 		division_template = "Artileriysky batalion"
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
@@ -4273,7 +4273,7 @@ units = {
 
 	division = {
 		name = "1-yy tankovoy batal'on 71-y otdel'nyy motostrelkovyy polk"
-		location = 2117
+		location = 18869
 		division_template = "Batalion T72"
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
@@ -4281,14 +4281,14 @@ units = {
 
 	division = {
 		name = "1-yy artileriyskiy batal'on 71-y otdel'nyy motostrelkovyy polk"
-		location = 2117
+		location = 18869
 		division_template = "Artileriysky batalion"
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
 	}
 	division = {
 		name = "2-yy artileriyskiy batal'on 71-y otdel'nyy motostrelkovyy polk"
-		location = 2117
+		location = 18869
 		division_template = "Artileriysky batalion"
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.01
@@ -4296,21 +4296,21 @@ units = {
 
 	division = {
 		name = "1-yy otdel'nyy otryad spetsial'nogo naznacheniya 22-ya otdel'naya gvardeyskaya brigada spetsial'nogo naznacheniya"
-		location = 9990
+		location = 9557
 		division_template = "Pechotniy batalion" #изменить на ССО
 		start_experience_factor = 0.3
 		start_equipment_factor = 0.01
 	}
 	division = {
 		name = "2-yy otdel'nyy otryad spetsial'nogo naznacheniya 22-ya otdel'naya gvardeyskaya brigada spetsial'nogo naznacheniya"
-		location = 2332
+		location = 18864
 		division_template = "Pechotniy batalion" #изменить на ССО
 		start_experience_factor = 0.3
 		start_equipment_factor = 0.01
 	}
 	division = {
 		name = "3-yy otdel'nyy otryad spetsial'nogo naznacheniya 22-ya otdel'naya gvardeyskaya brigada spetsial'nogo naznacheniya"
-		location = 14598
+		location = 16197
 		division_template = "Pechotniy batalion" #изменить на ССО
 		start_experience_factor = 0.3
 		start_equipment_factor = 0.01
@@ -4318,7 +4318,7 @@ units = {
 
 	division = {
 		name = "162-y otdel'nyy razvedyvatel'nyy batal'on 7-aya gvardeyskaya desantno-shturmovaya diviziya"
-		location = 14598
+		location = 16197
 		division_template = "Pechotniy batalion" 
 		start_experience_factor = 0.3
 		start_equipment_factor = 0.01
@@ -4326,7 +4326,7 @@ units = {
 
 	division = {
 		name = "70-y otdel'nyy otryad spetsial'nogo naznacheniya 2-ya otdel'naya gvardeyskaya brigada spetsial'nogo naznacheniya"
-		location = 18621
+		location = 19200
 		division_template = "Pechotniy batalion" #изменить на ССО
 		start_experience_factor = 0.3
 		start_equipment_factor = 0.01
@@ -4334,7 +4334,7 @@ units = {
 
 	division = {
 		name = "329-y otdel'nyy otryad spetsial'nogo naznacheniya 2-ya otdel'naya gvardeyskaya brigada spetsial'nogo naznacheniya"
-		location = 18621
+		location = 19200
 		division_template = "Pechotniy batalion" #изменить на ССО
 		start_experience_factor = 0.3
 		start_equipment_factor = 0.01
@@ -4342,7 +4342,7 @@ units = {
 
 	division = {
 		name = "700-y otdel'nyy otryad spetsial'nogo naznacheniya 2-ya otdel'naya gvardeyskaya brigada spetsial'nogo naznacheniya"
-		location = 18621
+		location = 19200
 		division_template = "Pechotniy batalion" #изменить на ССО
 		start_experience_factor = 0.3
 		start_equipment_factor = 0.01
@@ -4350,7 +4350,7 @@ units = {
 
 	division = {
 		name = "173-y otdel'nyy razvedyvatel'nyy batal'on 106-aya gvardeyskaya desantno-shturmovaya diviziya"
-		location = 18574
+		location = 3681
 		division_template = "Pechotniy batalion" 
 		start_experience_factor = 0.3
 		start_equipment_factor = 0.01


### PR DESCRIPTION
Некоторые люди могут длительное время не формировать фронт, из-за чего войска остаются на территории ЛДНР, где на 14.02.2024 16:15~ попросту нет снабжения, хотя ЛНР и ДНР являются марионетками. Даже если и формировать фронт, то любая клетка ЛДНР будет иметь нулевое снабжения, а значит войска будут в пустоту тратить снаряжение. Это отличное временное решение