### PR TITLE
Add seasonal energy consumption

### DIFF
--- a/common/on_actions/ES_energy_on_actions.txt
+++ b/common/on_actions/ES_energy_on_actions.txt
@@ -1,10 +1,11 @@
 on_actions = {
 	on_startup = {
 		effect = {
-			BOR = {
-				init_global_energy_data = yes
-				init_all_hydro_power_plants = yes
-			}
+                        BOR = {
+                                init_global_energy_data = yes
+                                init_all_hydro_power_plants = yes
+                                update_energy_season_consumption = yes
+                        }
 
 			if = {
 				limit = {
@@ -22,18 +23,33 @@ on_actions = {
 		}
 	}
 
-	on_weekly = {
-		effect = {
-			if = {
-				limit = {
-					has_game_rule = {
-						rule = ES_ENERGY_SYSTEM_STATUS
-						option = ES_ENERGY_SYSTEM_ENABLED
-					}
-				}
-				
-				calculate_energy_in_country = yes
-			}
-		}
-	}
+        on_weekly = {
+                effect = {
+                        if = {
+                                limit = {
+                                        has_game_rule = {
+                                                rule = ES_ENERGY_SYSTEM_STATUS
+                                                option = ES_ENERGY_SYSTEM_ENABLED
+                                        }
+                                }
+
+                                calculate_energy_in_country = yes
+                        }
+                }
+        }
+
+        on_monthly = {
+                effect = {
+                        if = {
+                                limit = {
+                                        has_game_rule = {
+                                                rule = ES_ENERGY_SYSTEM_STATUS
+                                                option = ES_ENERGY_SYSTEM_ENABLED
+                                        }
+                                }
+
+                                update_energy_month = yes
+                        }
+                }
+        }
 }

--- a/common/scripted_effects/ES_energy_constants_scripted_effects.txt
+++ b/common/scripted_effects/ES_energy_constants_scripted_effects.txt
@@ -62,5 +62,13 @@ init_global_energy_data = {
 	# Ограничение, что страна должна держать в запасе как минимум N% от потребления в электросети
 	set_variable = { global.energy_export_lower_bound_by_connected_consumption_factor = 0.2 }
 	# Множитель продажи электронегрии от текущего нетто
-	set_variable = { global.energy_export_by_netto_factor = 0.8 }
+       set_variable = { global.energy_export_by_netto_factor = 0.8 }
+
+       # ==== Сезонные множители потребления энергии ====
+       set_variable = { global.energy_season_winter_consumption_factor = 1.2 }
+       set_variable = { global.energy_season_spring_consumption_factor = 1.0 }
+       set_variable = { global.energy_season_summer_consumption_factor = 0.9 }
+       set_variable = { global.energy_season_autumn_consumption_factor = 1.1 }
+       set_variable = { global.energy_season_consumption_factor = 1 }
+       set_variable = { global.energy_current_month = 1 }
 }

--- a/common/scripted_effects/ES_energy_scripted_effects.txt
+++ b/common/scripted_effects/ES_energy_scripted_effects.txt
@@ -82,7 +82,8 @@ recalculate_country_energy_data = {
 	# Вместо множителя потребления меняем делитель потребления.
 	# Это позволит вычислять значения с меньшими потерями точности
 	set_variable = { energy_population_k_consumption_divider = global.energy_population_k_consumption_divider }
-	set_variable = { energy_population_k_consumption_factor = global.energy_population_k_consumption_factor }
+       set_variable = { energy_population_k_consumption_factor = global.energy_population_k_consumption_factor }
+       multiply_variable = { energy_population_k_consumption_factor = global.energy_season_consumption_factor }
 
 	set_temp_variable = { energy_population_consumption_factor_modifier = modifier@energy_population_consumption_factor }
 	clamp_temp_variable = { var = energy_population_consumption_factor_modifier min = 0.1 }
@@ -874,5 +875,51 @@ recalculate_state_hydro_power_plant = {
 	}
 
 	set_variable = { energy_hydro_power_plant_unit_medium_generation_power = gen_sum_power_temp }
-	divide_variable = { energy_hydro_power_plant_unit_medium_generation_power = gen_count_temp }
+divide_variable = { energy_hydro_power_plant_unit_medium_generation_power = gen_count_temp }
+}
+
+# === Seasonal energy mechanics ===
+update_energy_month = {
+       add_to_variable = { global.energy_current_month = 1 }
+       if = {
+               limit = { check_variable = { var = global.energy_current_month value = 13 compare = greater_than_or_equals } }
+               set_variable = { global.energy_current_month = 1 }
+       }
+       update_energy_season_consumption = yes
+}
+
+update_energy_season_consumption = {
+       if = {
+               limit = {
+                       OR = {
+                               check_variable = { var = global.energy_current_month value = 12 }
+                               check_variable = { var = global.energy_current_month value = 1 }
+                               check_variable = { var = global.energy_current_month value = 2 }
+                       }
+               }
+               set_variable = { global.energy_season_consumption_factor = global.energy_season_winter_consumption_factor }
+       }
+       else_if = {
+               limit = {
+                       OR = {
+                               check_variable = { var = global.energy_current_month value = 3 }
+                               check_variable = { var = global.energy_current_month value = 4 }
+                               check_variable = { var = global.energy_current_month value = 5 }
+                       }
+               }
+               set_variable = { global.energy_season_consumption_factor = global.energy_season_spring_consumption_factor }
+       }
+       else_if = {
+               limit = {
+                       OR = {
+                               check_variable = { var = global.energy_current_month value = 6 }
+                               check_variable = { var = global.energy_current_month value = 7 }
+                               check_variable = { var = global.energy_current_month value = 8 }
+                       }
+               }
+               set_variable = { global.energy_season_consumption_factor = global.energy_season_summer_consumption_factor }
+       }
+       else = {
+               set_variable = { global.energy_season_consumption_factor = global.energy_season_autumn_consumption_factor }
+       }
 }


### PR DESCRIPTION
## Summary
- initialize seasonal energy multipliers in global energy data
- modify population energy calculation to account for seasonal factor
- update energy season each month and on game start
- run monthly hook to advance months for energy system

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852267d478883229e44e9a4610f9897